### PR TITLE
Get cycle effective dates

### DIFF
--- a/example.js
+++ b/example.js
@@ -2,6 +2,8 @@ const terminalProcedures = require('./')
 
 terminalProcedures.fetchCurrentCycle().then(r => console.log(r))
 
+terminalProcedures.currentCycleEffectiveDates().then(console.log)
+
 // Also try updateing the Flag property to include one or more of the following:
 //  A for only those that were Added since the last effective date
 //  C for only those that were Changed since the last effective date

--- a/index.js
+++ b/index.js
@@ -33,7 +33,9 @@ terminalProcedures.currentCycleEffectiveDates = async () => {
     .get(BASE_URL)
     .set('Accept', ACCEPT)
   
-  return extractEffectiveDates(cheerio.load(response.text))
+  const $ = cheerio.load(response.text)
+  var currentCycle = $('select#cycle > option:contains(Current)').text()
+  return parseEffectiveDates(currentCycle.replace(/(\n|\t)/gm, ''))
 } 
 
 /**
@@ -213,7 +215,14 @@ const extractEffectiveDates = $ => {
   .split('<')[0]
   .trim()
 
-  const [ startMonthDay, remainder ] = baseEffectiveDateString.split('-')
+  return parseEffectiveDates(baseEffectiveDateString)
+}
+
+const parseEffectiveDates = str => {
+  if (!str) {
+    return null
+  }
+  const [ startMonthDay, remainder ] = str.split('-')
   const [ endMonthDay, yearAndCycle ] = remainder.split(',')
   const [ year, _ ] = yearAndCycle.split('[')
   return {

--- a/index.js
+++ b/index.js
@@ -28,6 +28,14 @@ terminalProcedures.list = (icaos, options = defaultQueryOptions) => {
   return listOne(icaos, options)
 }
 
+terminalProcedures.currentCycleEffectiveDates = async () => {
+  const response = await superagent
+    .get(BASE_URL)
+    .set('Accept', ACCEPT)
+  
+  return extractEffectiveDates(cheerio.load(response.text))
+} 
+
 /**
  * Fetch the current diagrams distribution cycle numbers (.e.g, 1813)
  */


### PR DESCRIPTION
Added a method to allow us to get just the effective dates for the current cycle. This will be useful in the event none of the terminal procedures for the queried batch have any changes between cycles. Currently they dates are mapped in to the record results, so if no data is changed, callers can't get the new effective dates.