### PR TITLE
Next cycle

### DIFF
--- a/example.js
+++ b/example.js
@@ -2,6 +2,8 @@ const terminalProcedures = require('./')
 
 terminalProcedures.fetchCurrentCycle().then(r => console.log(r))
 
+terminalProcedures.currentCycleEffectiveDates().then(console.log)
+
 // Also try updateing the Flag property to include one or more of the following:
 //  A for only those that were Added since the last effective date
 //  C for only those that were Changed since the last effective date

--- a/example.js
+++ b/example.js
@@ -46,18 +46,22 @@ terminalProcedures.currentCycleEffectiveDates().then(c => {
   console.log(c)
 })
 
-// Also try updateing the Flag property to include one or more of the following:
+// Also try updating the Flag property to include one or more of the following:
 //  A for only those that were Added since the last effective date
 //  C for only those that were Changed since the last effective date
 //  D for only those that were Deleted since the last effective date
 //  Leave empty to get all regardless of if they've been added or changed
-terminalProcedures.list('PANC', { flag: [ ], }).then(results => {
+// The `getNextCycle` option will get the next cycle if it is available when set to true
+//  If it is omitted or set to false, the current cycle will be queried
+terminalProcedures.list('PANC', { flag: [ ], getNextCycle: true, }).then(results => {
   console.log(results)
   const out = results.map(tp => {
     return {
       name: tp.procedure.name,
       type: tp.type,
-      url: tp.procedure.url
+      url: tp.procedure.url,
+      effectiveStartDate: tp.effectiveStartDate,
+      effectiveEndDate: tp.effectiveEndDate,
     }
   })
   console.log(

--- a/example.js
+++ b/example.js
@@ -1,15 +1,57 @@
 const terminalProcedures = require('./')
 
-terminalProcedures.fetchCurrentCycle().then(r => console.log(r))
+// Should log current cycle effective object
+terminalProcedures.fetchCycle().then(c => {
+  console.log('current cycle effective object, no param')
+  console.dir(c)
+})
 
-terminalProcedures.currentCycleEffectiveDates().then(console.log)
+// Should log current cycle effective object
+terminalProcedures.fetchCycle('Current').then(c => {
+  console.log('current cycle effective object, with param')
+  console.dir(c)
+})
+
+// Should log next cycle effective object
+terminalProcedures.fetchCycle('Next').then(c => {
+  console.log('next cycle effective object, with param')
+  console.dir(c)
+})
+
+// Should log current cycle code
+terminalProcedures.fetchCurrentCycleCode().then(c => {
+  console.log('current cycle code')
+  console.log(c)
+})
+
+// Should log the current cycle effective dates
+terminalProcedures.getCycleEffectiveDates().then(c => {
+  console.log('the current cycle effective dates, no param')
+  console.log(c)
+})
+// Should log the current cycle effective dates
+terminalProcedures.getCycleEffectiveDates('Current').then(c => {
+  console.log('the current cycle effective dates, with param')
+  console.log(c)
+})
+// Should log the next cycle effective dates
+terminalProcedures.getCycleEffectiveDates('Next').then(c => {
+  console.log('the next cycle effective dates')
+  console.log(c)
+})
+
+// Should log the current cycle effective dates
+terminalProcedures.currentCycleEffectiveDates().then(c => {
+  console.log('the current cycle effective dates')
+  console.log(c)
+})
 
 // Also try updateing the Flag property to include one or more of the following:
 //  A for only those that were Added since the last effective date
 //  C for only those that were Changed since the last effective date
 //  D for only those that were Deleted since the last effective date
 //  Leave empty to get all regardless of if they've been added or changed
-terminalProcedures.list('PANC', { flag: [ 'A', 'C' ], }).then(results => {
+terminalProcedures.list('PANC', { flag: [ ], }).then(results => {
   console.log(results)
   const out = results.map(tp => {
     return {

--- a/index.js
+++ b/index.js
@@ -109,7 +109,20 @@ terminalProcedures.fetchNextCycleCode = fetchNextCycleCode
  * @returns {Array} - The scraped terminal procedures
  */
 const listOne = async (icao, options) => {
-  const searchCycle = await fetchCurrentCycleCode()
+  let searchCycle = null
+  
+  if (options.getNextCycle === true) {
+    searchCycle = await fetchNextCycleCode()
+  }
+
+  // If the next cycle is not requested, or it is, but it is not
+  // available, default to the current cycle
+  if (searchCycle === null) {
+    if (options.getNextCycle === true) {
+      console.warn('Next cycle not available. Retrieving current cycle instead.')
+    }
+    searchCycle = await fetchCurrentCycleCode()
+  }
 
   // Build up a base set of query params
   let urlParams = [ 'sort=type', 'dir=asc', `ident=${icao}`, ]

--- a/index.js
+++ b/index.js
@@ -33,7 +33,9 @@ terminalProcedures.currentCycleEffectiveDates = async () => {
     .get(BASE_URL)
     .set('Accept', ACCEPT)
   
-  return extractEffectiveDates(cheerio.load(response.text))
+  const $ = cheerio.load(response.text)
+  var currentCycle = $('select#cycle > option:contains(Current)').text()
+  return parseEffectiveDates(currentCycle.replace(/(\n|\t)/gm, ''))
 } 
 
 /**
@@ -213,7 +215,14 @@ const extractEffectiveDates = $ => {
   .split('<')[0]
   .trim()
 
-  const [ startMonthDay, remainder ] = baseEffectiveDateString.split('-')
+  return parseEffectiveDates(baseEffectiveDateString)
+}
+
+const parseEffectiveDates = str => {
+  if (!str) {
+    return null
+  }
+  const [ startMonthDay, remainder ] = str.split('-')
   const [ endMonthDay, yearAndCycle ] = remainder.split(',')
   const [ year, _ ] = yearAndCycle.split('[')
   return {

--- a/index.js
+++ b/index.js
@@ -28,6 +28,14 @@ terminalProcedures.list = (icaos, options = defaultQueryOptions) => {
   return listOne(icaos, options)
 }
 
+terminalProcedures.currentCycleEffectiveDates = async () => {
+  const response = await superagent
+    .get(BASE_URL)
+    .set('Accept', ACCEPT)
+  
+  return extractEffectiveDates(cheerio.load(response.text))
+} 
+
 /**
  * Fetch the current diagrams distribution cycle numbers (.e.g, 1813)
  */

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const ACCEPT = 'text/html'
 
 const defaultQueryOptions = {
   flag: [], // 'A' - Added, 'C' - Changed, 'D' - Deleted, Empty - All valid procedures
+  getNextCycle: false // `false` do not get the 'Next' cycle, only get the 'Current' cycle; `true` get the 'Next' cycle if available
 }
 
 /**
@@ -28,27 +29,77 @@ terminalProcedures.list = (icaos, options = defaultQueryOptions) => {
   return listOne(icaos, options)
 }
 
-terminalProcedures.currentCycleEffectiveDates = async () => {
+/**
+ * Returns the text and values of the targeted <select/> element
+ * @param {string} cycle - The target cycle to retrieve. Valid values are 'Current' or 'Next'
+ */
+const fetchCycle = async (cycle = 'Current') => {
+  // Only all the values 'Current' or 'Next'
+  if (cycle !== 'Current' && cycle !== 'Next') {
+    cycle = 'Current'
+  }
   const response = await superagent
     .get(BASE_URL)
     .set('Accept', ACCEPT)
   
   const $ = cheerio.load(response.text)
-  var currentCycle = $('select#cycle > option:contains(Current)').text()
+  const $cycle = $(`select#cycle > option:contains(${cycle})`)
+  if (!$cycle) {
+    return $cycle
+  }
+  return {
+    text: $cycle.text(),
+    val: $cycle.val()
+  }
+}
+
+/**
+ * Returns the text and values of the targeted <select/> element
+ * @param {string} cycle - The target cycle to retrieve. Valid values are 'Current' or 'Next'
+ */
+terminalProcedures.fetchCycle = fetchCycle
+
+terminalProcedures.getCycleEffectiveDates = async (cycle = 'Current') => {
+  const { text: currentCycle, } = await fetchCycle(cycle)
   return parseEffectiveDates(currentCycle.replace(/(\n|\t)/gm, ''))
 } 
+
+terminalProcedures.currentCycleEffectiveDates = async () => {
+  const { text: currentCycle, } = await fetchCycle()
+  if (!currentCycle) {
+    console.warn('Could not retrieve current cycle effective dates')
+    return
+  }
+  return parseEffectiveDates(currentCycle.replace(/(\n|\t)/gm, ''))
+}
 
 /**
  * Fetch the current diagrams distribution cycle numbers (.e.g, 1813)
  */
-const fetchCurrentCycle = (terminalProcedures.fetchCurrentCycle = async () => {
-  const response = await superagent
-    .get(BASE_URL)
-    .set('Accept', ACCEPT)
+const fetchCurrentCycleCode = async () => {
+  const cycle = await fetchCycle('Current')
+  if (!cycle) {
+    console.warn('Current cycle not found or not available.')
+    return null
+  }
+  return cycle.val
+}
 
-  const $ = cheerio.load(response.text)
-  return $('select#cycle > option:contains(Current)').val()
-})
+terminalProcedures.fetchCurrentCycleCode = fetchCurrentCycleCode
+
+/**
+ * Fetch the current diagrams distribution cycle numbers (.e.g, 1813)
+ */
+const fetchNextCycleCode = async () => {
+  const cycle = await fetchCycle('Next')
+  if (!cycle) {
+    console.warn('Next cycle not found or not available. The Next cycle is available 19 days before the end of the current cycle.')
+    return null
+  }
+  return cycle.val
+}
+
+terminalProcedures.fetchNextCycleCode = fetchNextCycleCode
 
 /**
  * Using the current cycle, fetch the terminal procedures for a single ICAO code
@@ -58,7 +109,7 @@ const fetchCurrentCycle = (terminalProcedures.fetchCurrentCycle = async () => {
  * @returns {Array} - The scraped terminal procedures
  */
 const listOne = async (icao, options) => {
-  const searchCycle = await fetchCurrentCycle()
+  const searchCycle = await fetchCurrentCycleCode()
 
   // Build up a base set of query params
   let urlParams = [ 'sort=type', 'dir=asc', `ident=${icao}`, ]
@@ -225,10 +276,14 @@ const parseEffectiveDates = str => {
   const [ startMonthDay, remainder ] = str.split('-')
   const [ endMonthDay, yearAndCycle ] = remainder.split(',')
   const [ year, _ ] = yearAndCycle.split('[')
-  return {
-    effectiveStartDate: new Date(`${startMonthDay.trim()} ${year}`),
-    effectiveEndDate: new Date(`${endMonthDay.trim()} ${year}`)
-  }
+
+  const effectiveStartDate = new Date(`${startMonthDay.trim()} ${year}`)
+  effectiveStartDate.setUTCHours(0,0,0,0)
+
+  const effectiveEndDate = new Date(`${endMonthDay.trim()} ${year}`)
+  effectiveEndDate.setUTCHours(0,0,0,0)
+
+  return { effectiveStartDate, effectiveEndDate }
 }
 
 /**


### PR DESCRIPTION
Add methods to allow users to retrieve the Next cycle's effective dates and terminal procedures, when available. Provide console warnings when the Next cycle is not found.

Added more calls to `example.js` to demo the methods.

Open a terminal and change directories to the root of this repo, then execute `node ./example.js` to run the script and inspect the output in the console.