### PR TITLE
Fix effectiveStartDate being after effectiveEndDate

### DIFF
--- a/index.js
+++ b/index.js
@@ -307,9 +307,16 @@ const parseEffectiveDates = str => {
   const [ year, _ ] = yearAndCycle.split('[')
 
   const effectiveStartDate = new Date(`${startMonthDay.trim()} ${year}`)
-  effectiveStartDate.setUTCHours(0,0,0,0)
-
   const effectiveEndDate = new Date(`${endMonthDay.trim()} ${year}`)
+
+  // If effectiveStartDate does not have a year specified,
+  // it will default to the same year as effectiveEndDate.
+  // So if the date range spans Jan 1, roll effectiveStartDate back one year.
+  if (effectiveStartDate > effectiveEndDate) {
+    effectiveStartDate.setFullYear(effectiveStartDate.getFullYear() - 1 );
+  }
+
+  effectiveStartDate.setUTCHours(0,0,0,0)
   effectiveEndDate.setUTCHours(0,0,0,0)
 
   return { effectiveStartDate, effectiveEndDate }


### PR DESCRIPTION
I noticed that the current terminal procedures were being returned with effective dates Dec 30, **_2022_** - Jan 26, 2022.  

There was a problem parsing the start date when the year isn't specified in the text parsed from the FAA site(such as "Dec 30 - Jan 26, 2022"), and the start year is different from the end year.  This PR fixes that.