### PR TITLE
Add response timeout limits to requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,18 +29,6 @@ terminalProcedures.list = (icaos, options = defaultQueryOptions) => {
   return listOne(icaos, options)
 }
 
-terminalProcedures.currentCycleEffectiveDates = async () => {
-  const response = await superagent
-    .get(BASE_URL)
-    .set('Accept', ACCEPT)
-    .timeout({ deadline: 30000 })
-    .retry(3)
-
-  const $ = cheerio.load(response.text)
-  var currentCycle = $('select#cycle > option:contains(Current)').text()
-  return parseEffectiveDates(currentCycle.replace(/(\n|\t)/gm, ''))
-}
-
 /**
  * Returns the text and values of the targeted <select/> element
  * @param {string} cycle - The target cycle to retrieve. Valid values are 'Current' or 'Next'
@@ -75,16 +63,15 @@ terminalProcedures.fetchCycle = fetchCycle
 
 terminalProcedures.getCycleEffectiveDates = async (cycle = 'Current') => {
   const { text: currentCycle, } = await fetchCycle(cycle)
+  if (!currentCycle) {
+    console.warn(`Could not retrieve ${cycle} cycle effective dates`)
+    return
+  }
   return parseEffectiveDates(currentCycle.replace(/(\n|\t)/gm, ''))
 }
 
 terminalProcedures.currentCycleEffectiveDates = async () => {
-  const { text: currentCycle, } = await fetchCycle()
-  if (!currentCycle) {
-    console.warn('Could not retrieve current cycle effective dates')
-    return
-  }
-  return parseEffectiveDates(currentCycle.replace(/(\n|\t)/gm, ''))
+  return getCycleEffectiveDates()
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -42,8 +42,8 @@ const fetchCycle = async (cycle = 'Current') => {
     .get(BASE_URL)
     .set('Accept', ACCEPT)
     .timeout({
-      response: 30e3,
-      deadline: 60e3
+      response: 10e3,
+      deadline: 30e3
     })
     .retry(3)
 
@@ -202,7 +202,7 @@ const getProcedures = async url => superagent
   .set('Accept', ACCEPT)
   .timeout({
     response: 10e3,
-    deadline: 60e3
+    deadline: 30e3
   })
   .retry(3)
   .then(res => parse(res.text))


### PR DESCRIPTION
A bit of code clean-up here. 

The only functional change is adding `response` time limits to the Superagent requests.  For fetching the current cycle metadata, I set the response timeout at 30 seconds.  That request is important to almost all terminal procedures steps, so I wanted to give it plenty of time to complete.  I set the response timeout for fetching the actual procedures to 10 seconds, since we usually have a bunch of those to do, so we don't want to wait too long on any single one. 